### PR TITLE
Mark repo as archived, point to protected-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+Archived Content
+================
+
+This repository is an archive of the memory hole protected e-mail headers effort.
+It has been inactive for a few years.
+
+The most recent effort in this field is documented here: https://github.com/autocrypt/protected-headers
+It tracks the Internet Draft documenting shared experience in providing end-to-end cryptographic protection for e-mail headers.
+
 Memory Hole Protected E-mail Headers
 ====================================
 


### PR DESCRIPTION
This repository and the memory hole effort have been inactive for quite a while.
Protected-headers is the closest thing there is to a successor.

Make sure it's obvious from the Readme that people should probably check out protected headers instead.